### PR TITLE
🔀 :: 프론트 개발섭의 cors 허용

### DIFF
--- a/src/main/kotlin/com/msg/gauth/global/web/WebMvcConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/web/WebMvcConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebMvcConfig: WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3000", "https://gauth.co.kr", "https://www.gauth.co.kr")
+            .allowedOrigins("http://localhost:3000", "https://gauth.co.kr", "https://www.gauth.co.kr", "https://dev-gauth-frontend.vercel.app")
             .allowedMethods("*")
             .allowedHeaders("*")
             .exposedHeaders("Authorization")


### PR DESCRIPTION
## 💡 개요
프론트 개발섭의 cors를 허용해줍니다

## 📃 작업내용
WebMvcConfig에서 cors에 https://dev-gauth-frontend.vercel.app 해당 url을 허어요옹하압니이다아