### PR TITLE
유저 회원가입 수락에 졸업생 수락 기능 추가

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -44,6 +44,7 @@ class User(
     @Column(nullable = true, columnDefinition = "TEXT")
     val profileUrl: String?,
 ): BaseIdEntity(){
+
     fun update(name: String, grade: Int, classNum: Int, num: Int, gender: Gender): User{
         val user = User(
             name = name,
@@ -61,7 +62,7 @@ class User(
         return user
     }
 
-    fun update(name: String, gender: Gender): User {
+    fun updateTeacher(name: String, gender: Gender): User {
         val user = User(
             name = name,
             email = this.email,
@@ -71,6 +72,23 @@ class User(
             gender = gender,
             password = this.password,
             roles = mutableListOf(UserRole.ROLE_TEACHER),
+            state = UserState.CREATED,
+            profileUrl = this.profileUrl
+        )
+        user.id = this.id
+        return user
+    }
+
+    fun updateGraduate(name: String, gender: Gender): User {
+        val user = User(
+            name = name,
+            email = this.email,
+            grade = this.grade,
+            classNum = this.classNum,
+            num = this.num,
+            gender = gender,
+            password = this.password,
+            roles = mutableListOf(UserRole.ROLE_GRADUATE),
             state = UserState.CREATED,
             profileUrl = this.profileUrl
         )

--- a/src/main/kotlin/com/msg/gauth/domain/user/enums/UserRole.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/enums/UserRole.kt
@@ -3,7 +3,7 @@ package com.msg.gauth.domain.user.enums
 import org.springframework.security.core.GrantedAuthority
 
 enum class UserRole : GrantedAuthority {
-    ROLE_STUDENT, ROLE_TEACHER, ROLE_ADMIN;
+    ROLE_STUDENT, ROLE_TEACHER, ROLE_ADMIN, ROLE_GRADUATE;
 
     override fun getAuthority(): String =
         name

--- a/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptTeacherSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptTeacherSignUpService.kt
@@ -16,7 +16,7 @@ class AcceptTeacherSignUpService(
     fun execute(acceptTeacherReqDto: AcceptTeacherReqDto) {
         val user: User = userRepository.findByIdAndStateAndRoles(acceptTeacherReqDto.id, UserState.PENDING, mutableListOf(UserRole.ROLE_TEACHER))
             ?: throw UserNotFoundException()
-        user.update(acceptTeacherReqDto.name, acceptTeacherReqDto.gender)
+        user.updateTeacher(acceptTeacherReqDto.name, acceptTeacherReqDto.gender)
             .let { userRepository.save(it) }
     }
 }

--- a/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptUserSignUpService.kt
@@ -29,7 +29,6 @@ class AcceptUserSignUpService(
         getUser(id).update(acceptUserReqDto)
             .let { userRepository.save(it) }
 
-
     private fun acceptTeacher(id: Long, acceptUserReqDto: AcceptUserReqDto) =
         getUser(id).updateTeacher(acceptUserReqDto.name, acceptUserReqDto.gender)
             .let { userRepository.save(it) }

--- a/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/services/AcceptUserSignUpService.kt
@@ -17,6 +17,7 @@ class AcceptUserSignUpService(
         when(acceptUserReqDto.userRole){
             UserRole.ROLE_STUDENT -> acceptStudent(id, acceptUserReqDto)
             UserRole.ROLE_TEACHER -> acceptTeacher(id, acceptUserReqDto)
+            UserRole.ROLE_GRADUATE -> acceptGraduate(id, acceptUserReqDto)
             else -> throw BadUserRoleRequestException()
         }
 
@@ -30,7 +31,11 @@ class AcceptUserSignUpService(
 
 
     private fun acceptTeacher(id: Long, acceptUserReqDto: AcceptUserReqDto) =
-        getUser(id).update(acceptUserReqDto.name, acceptUserReqDto.gender)
+        getUser(id).updateTeacher(acceptUserReqDto.name, acceptUserReqDto.gender)
+            .let { userRepository.save(it) }
+
+    private fun acceptGraduate(id: Long, acceptUserReqDto: AcceptUserReqDto) =
+        getUser(id).updateGraduate(acceptUserReqDto.name, acceptUserReqDto.gender)
             .let { userRepository.save(it) }
 
 }


### PR DESCRIPTION
## 💡 개요
유저 회원가입 수락에 졸업생 수락 기능 추가 🔨
## 📃 작업내용
user의 업데이트 함수중 Teacher, Graduate의 업데이트 함수를 
updateTeacher updateGraduate로 메서드 명을 변경했습니다. ✍️

## 🔀 변경사항
user entity update Method name, AcceptUserSignUpService

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타
