### PR TITLE
🔀 ::Response DTO 학년/반/번호 nullable 변수로 변경

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/SingleAcceptedUserResDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/SingleAcceptedUserResDto.kt
@@ -6,18 +6,18 @@ data class SingleAcceptedUserResDto(
     val id: Long,
     val name: String,
     val email: String,
-    val grade: Int,
-    val classNum: Int,
-    val num: Int,
+    val grade: Int?,
+    val classNum: Int?,
+    val num: Int?,
     val profileUrl: String?
 ) {
     constructor(user: User): this(
         user.id,
         user.name!!,
         user.email,
-        user.grade!!,
-        user.classNum!!,
-        user.num!!,
+        user.grade,
+        user.classNum,
+        user.num,
         user.profileUrl
     )
 }


### PR DESCRIPTION
## 💡 개요
수락된 유저 리스트 api의 Response DTO 변수 중 학년, 반, 번호를 nullable로 변경하였습니다
선생님과 졸업생을 반환하는 새로운 기능이 생기면서 가지고 있지 않는 학년, 반, 번호를 null로 담아야 하기 때문입니다
## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타
